### PR TITLE
Fixed a bug where blurred SurfaceView (Google Map) does not update

### DIFF
--- a/blurbehindlib/src/main/java/no/danielzeller/blurbehindlib/BlurBehindLayout.kt
+++ b/blurbehindlib/src/main/java/no/danielzeller/blurbehindlib/BlurBehindLayout.kt
@@ -240,6 +240,8 @@ class BlurBehindLayout : FrameLayout {
         } else {
             (renderView as GLSurfaceView).requestRender()
         }
+
+        viewBehind?.requestLayout()
     }
 
     private var frameCallBack = Choreographer.FrameCallback {


### PR DESCRIPTION
When blurring another SurfaceView/TextureView like Google Maps MapView for example. The BlurBehindLayout takes the renderer of that view and it becomes unresponsive. For example, moving the map around will show in the blurred view, but not in the main MapView.

I would imagine there is probably a more efficient way of fixing this instead of calling `requestLayout()` on each update, but I am not skilled enough to get to the bottom of it.