### PR TITLE
Public ‘initView’ method to prevent NullPointerException when Surface unexpectedly released

### DIFF
--- a/blurbehindlib/src/main/java/no/danielzeller/blurbehindlib/BlurBehindLayout.kt
+++ b/blurbehindlib/src/main/java/no/danielzeller/blurbehindlib/BlurBehindLayout.kt
@@ -90,6 +90,7 @@ class BlurBehindLayout : FrameLayout {
     private var isBlurDisabled = false
     private var paddingVertical = 0f
     private val onScrollChangesListener = ViewTreeObserver.OnScrollChangedListener { updateForMilliSeconds(200) }
+    private var isRenderViewReleased = false
 
     constructor(context: Context, useTextureView: Boolean, blurTextureScale: Float, paddingVertical: Float) : super(context) {
         this.blurTextureScale = blurTextureScale
@@ -224,6 +225,10 @@ class BlurBehindLayout : FrameLayout {
     }
 
     private fun redrawBlurTexture() {
+        if (isRenderViewReleased) {
+            initView(context)
+            isRenderViewReleased = false
+        }
         if (commonRenderer!!.isCreated && renderView.visibility == View.VISIBLE) {
             renderBehindViewToTexture()
             renderChildViewToTexture()
@@ -301,6 +306,7 @@ class BlurBehindLayout : FrameLayout {
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
+        isRenderViewReleased = true
         Choreographer.getInstance().removeFrameCallback(frameCallBack)
         viewTreeObserver.removeOnScrollChangedListener(onScrollChangesListener)
         commonRenderer?.destroyResources()

--- a/blurbehindlib/src/main/java/no/danielzeller/blurbehindlib/BlurBehindLayout.kt
+++ b/blurbehindlib/src/main/java/no/danielzeller/blurbehindlib/BlurBehindLayout.kt
@@ -151,7 +151,7 @@ class BlurBehindLayout : FrameLayout {
         }
     }
 
-    private fun initView(context: Context) {
+    fun initView(context: Context) {
         commonRenderer = CommonRenderer(context, blurTextureScale, useChildAlphaAsMask, paddingVertical)
         commonRenderer!!.blurRadius = blurRadius
         if (useTextureView) {


### PR DESCRIPTION
This change addresses the issue of Surface release under specific scenarios, ensuring stable functionality for BlurBehindLayout.

The surface of BlurBehindLayout may get released during screen lock or when the app is sent to the background, causing BlurBehindLayout to turn into a black screen when the activity regains focus. Attempting to update BlurBehindLayout results in IllegalStateException or NullPointerException due to the Surface being already released or locked, leading to app crashes.

The commit makes ‘’initView‘’ method public. This adjustment provides a solution to refresh surface by calling 'BlurBehindLayout.initView(context)'. allowing recreating surface when activity regains focus to preventing crashes.







